### PR TITLE
Prevent unwanted display of frame

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -37,6 +37,11 @@ class CompodocFrame extends React.Component {
   }
 
   render() {
+    const { active } = this.props;
+    if(!active) {
+      return null;
+    }
+    
     const { componentName, compodocUrl } = this.state;
     if (compodocUrl && componentName) {
       return (
@@ -64,6 +69,6 @@ class CompodocFrame extends React.Component {
 addons.register(`${ORG_KEY}/${ADDON_KEY}`, api => {
   addons.addPanel(`${ORG_KEY}/${ADDON_KEY}panel`, {
     title: "Compodoc",
-    render: () => <CompodocFrame channel={addons.getChannel()} api={api} />
+    render: ({ active, key }) => <CompodocFrame active={active} key={key} channel={addons.getChannel()} api={api} />
   });
 });


### PR DESCRIPTION
Only display frame when tab is active

Solution from:
https://github.com/storybookjs/storybook/blob/master/addons/knobs/src/components/Panel.js#L162
https://github.com/storybookjs/storybook/blob/master/addons/knobs/src/register.js#L10